### PR TITLE
Add royal.EthClient to this repo

### DIFF
--- a/multicall/options.go
+++ b/multicall/options.go
@@ -1,36 +1,27 @@
 package multicall
 
-import "fmt"
-
 type Option func(*Config)
 
+// Config defines the Config for a multicall client
 type Config struct {
-	MulticallAddress string
-	Gas				 string
+    MulticallAddress string
+    Gas              uint64
 }
 
 const (
-	// MainnetMulticall : Multicall contract address on mainnet
-	MainnetAddress = "0x5eb3fa2dfecdde21c950813c665e9364fa609bd2"
-	// RopstenMulticall : Multicall contract address on Ropsten
-	RopstenAddress = "0xf3ad7e31b052ff96566eedd218a823430e74b406"
+// TODO: Add Multicall addresses for various networks
 )
 
-
-func ContractAddress(address string) Option {
-	return func(c *Config) {
-		c.MulticallAddress = address
-	}
+// SetContractAddress will update the contract address for the Config
+func SetContractAddress(address string) Option {
+    return func(c *Config) {
+        c.MulticallAddress = address
+    }
 }
 
+// SetGas will update the gas limit to the given value
 func SetGas(gas uint64) Option {
-	return func(c *Config) {
-		c.Gas = fmt.Sprintf("0x%x", gas)
-	}
-}
-
-func SetGasHex(gas string) Option {
-	return func(c *Config) {
-		c.Gas = gas
-	}
+    return func(c *Config) {
+        c.Gas = gas
+    }
 }

--- a/royal/royal_eth_client.go
+++ b/royal/royal_eth_client.go
@@ -1,0 +1,51 @@
+// Package royal is for utilities that should be shared by all golang apps at royal
+package royal
+
+import (
+    "fmt"
+
+    "github.com/ethereum/go-ethereum"
+    "github.com/ethereum/go-ethereum/accounts/abi/bind"
+    "github.com/ethereum/go-ethereum/ethclient"
+)
+
+// EthClient is an interface that supports all the methods of backends.SimulatedBackend and ethclient.Client so mocking
+// is way easier. This is interface that should be used in our code
+type EthClient interface {
+    ethereum.ChainStateReader
+    ethereum.PendingStateReader
+    ethereum.GasPricer
+    ethereum.GasEstimator
+    ethereum.TransactionReader
+    ethereum.TransactionSender
+    bind.ContractBackend
+
+    // GetChainID is a helper method for retrieving the ChainId of the current chain
+    GetChainID() uint64
+}
+
+// ethClient is an implementation of the EthClient interface. This interface is used so we have a layer of
+// indirection between the ethclient.Client struct so we can more effectively mock our code and also simplify the
+// places that we interact with an eth-compatible network
+type ethClient struct {
+    *ethclient.Client
+    chainID uint64
+}
+
+// NewClient initializes a new connection to the given chainID given the rpcURL
+func NewClient(chainID uint64, rpcURL string) (EthClient, error) {
+    client, err := ethclient.Dial(rpcURL)
+    if err != nil {
+        return nil, fmt.Errorf("trouble creating ethClient for (chainID:%d): %s\n", chainID, err)
+    }
+
+    return &ethClient{
+        Client:  client,
+        chainID: chainID,
+    }, nil
+}
+
+// GetChainID returns the chainID for this client
+func (rec *ethClient) GetChainID() uint64 {
+    return rec.chainID
+}


### PR DESCRIPTION
This migrates from the `web3` library this package was using before and instead uses the native `ethclient.Client`, but packaged into an interface that supports both that `Client` as well as the `SimulatedBackend` to make testing significantly easier. 

`crypto-gateway` will also import this type. 